### PR TITLE
Timelock

### DIFF
--- a/contracts/utils/TimeLock.sol
+++ b/contracts/utils/TimeLock.sol
@@ -7,12 +7,14 @@ import "./RevertMsgExtractor.sol";
 
 interface ITimeLock {
     function setDelay(uint32 delay_) external;
-    function queue(address[] memory targets, bytes[] memory data, uint32 eta) external returns (bytes32 txHash);
+    function schedule(address[] memory targets, bytes[] memory data, uint32 eta) external returns (bytes32 txHash);
     function cancel(address[] memory targets, bytes[] memory data, uint32 eta) external;
     function execute(address[] memory targets, bytes[] memory data, uint32 eta) external returns (bytes[] memory results);
 }
 
 contract TimeLock is ITimeLock, AccessControl {
+    enum State {UNKNOWN, SCHEDULED, CANCELLED, EXECUTED}
+
     uint32 public constant GRACE_PERIOD = 14 days;
     uint32 public constant MINIMUM_DELAY = 2 days;
     uint32 public constant MAXIMUM_DELAY = 30 days;
@@ -20,23 +22,23 @@ contract TimeLock is ITimeLock, AccessControl {
     event DelaySet(uint32 indexed delay);
     event Cancelled(bytes32 indexed txHash, address[] indexed targets, bytes[] data, uint32 eta);
     event Executed(bytes32 indexed txHash, address[] indexed targets, bytes[] data, uint32 eta);
-    event Queued(bytes32 indexed txHash, address[] indexed targets, bytes[] data, uint32 eta);
+    event Scheduled(bytes32 indexed txHash, address[] indexed targets, bytes[] data, uint32 eta);
 
     uint32 public delay;
-    mapping (bytes32 => bool) public queued;
+    mapping (bytes32 => State) public transactions;
 
     constructor() AccessControl() {
         delay = MINIMUM_DELAY;
 
-        // msg.sender can queue, cancel, and execute transactions
-        _grantRole(ITimeLock.queue.selector, msg.sender); // bytes4(keccak256("queue(address[],bytes[],uint32)"))
+        // msg.sender can schedule, cancel, and execute transactions
+        _grantRole(ITimeLock.schedule.selector, msg.sender); // bytes4(keccak256("schedule(address[],bytes[],uint32)"))
         _grantRole(ITimeLock.cancel.selector, msg.sender); // bytes4(keccak256("cancel(address[],bytes[],uint32)"))
         _grantRole(ITimeLock.execute.selector, msg.sender); // bytes4(keccak256("execute(address[],bytes[],uint32)"))
 
         // Changing the delay must now be executed through this TimeLock contract
         _grantRole(ITimeLock.setDelay.selector, address(this)); // bytes4(keccak256("setDelay(uint32)"))
 
-        // Granting roles (queue, cancel, execute, setDelay) must now be executed through this TimeLock contract
+        // Granting roles (schedule, cancel, execute, setDelay) must now be executed through this TimeLock contract
         _grantRole(ROOT, address(this));
         _revokeRole(ROOT, msg.sender);
     }
@@ -51,24 +53,24 @@ contract TimeLock is ITimeLock, AccessControl {
     }
 
     /// @dev Schedule a transaction batch for execution between `eta` and `eta + GRACE_PERIOD`
-    function queue(address[] memory targets, bytes[] memory data, uint32 eta)
+    function schedule(address[] memory targets, bytes[] memory data, uint32 eta)
         external override auth returns (bytes32 txHash)
     {
         require(targets.length == data.length, "Mismatched inputs");
         require(eta >= uint32(block.timestamp) + delay, "Must satisfy delay.");
         
         txHash = keccak256(abi.encode(targets, data, eta));
-        queued[txHash] = true;
-        emit Queued(txHash, targets, data, eta);
+        transactions[txHash] = State.SCHEDULED;
+        emit Scheduled(txHash, targets, data, eta);
     }
 
-    /// @dev Cancel a scheduled  transaction batch
+    /// @dev Cancel a scheduled transaction batch
     function cancel(address[] memory targets, bytes[] memory data, uint32 eta)
         external override auth
     {
         require(targets.length == data.length, "Mismatched inputs");
         bytes32 txHash = keccak256(abi.encode(targets, data, eta));
-        queued[txHash] = false;
+        transactions[txHash] = State.CANCELLED;
         emit Cancelled(txHash, targets, data, eta);
     }
 
@@ -80,8 +82,8 @@ contract TimeLock is ITimeLock, AccessControl {
         require(uint32(block.timestamp) >= eta, "ETA not reached.");
         require(uint32(block.timestamp) <= eta + GRACE_PERIOD, "Transaction is stale.");
         bytes32 txHash = keccak256(abi.encode(targets, data, eta));
-        require(queued[txHash] == true, "Transaction hasn't been queued.");
-        queued[txHash] = false;
+        require(transactions[txHash] == State.SCHEDULED, "Transaction hasn't been transactions.");
+        transactions[txHash] = State.EXECUTED;
 
         results = new bytes[](targets.length);
         for (uint256 i = 0; i < targets.length; i++){

--- a/contracts/utils/TimeLock.sol
+++ b/contracts/utils/TimeLock.sol
@@ -1,0 +1,93 @@
+// SPDX-License-Identifier: MIT
+// Inspired on TimeLock.sol from Compound.
+
+pragma solidity ^0.8.0;
+import "../access/AccessControl.sol";
+import "./RevertMsgExtractor.sol";
+
+
+contract TimeLock is AccessControl {
+    uint32 public constant GRACE_PERIOD = 14 days;
+    uint32 public constant MINIMUM_DELAY = 2 days;
+    uint32 public constant MAXIMUM_DELAY = 30 days;
+
+    event DelaySet(uint32 indexed delay);
+    event TransactionCancelled(bytes32 indexed txHash, address indexed target, bytes data, uint256 index, uint256 length, uint32 eta);
+    event TransactionExecuted(bytes32 indexed txHash, address indexed target, bytes data, uint256 index, uint256 length, uint32 eta);
+    event TransactionQueued(bytes32 indexed txHash, address indexed target, bytes data, uint256 index, uint256 length, uint32 eta);
+
+    uint32 public delay;
+    mapping (bytes32 => bool) public queued;
+
+    constructor() AccessControl() {
+        delay = MINIMUM_DELAY;
+
+        // msg.sender can queue, cancel, and execute transactions
+        _grantRole(bytes4(keccak256("queue(address[],bytes[],uint32)")), msg.sender);
+        _grantRole(bytes4(keccak256("cancel(address[],bytes[],uint32)")), msg.sender);
+        _grantRole(bytes4(keccak256("execute(address[],bytes[],uint32)")), msg.sender);
+
+        // Changing the delay must now be executed through this TimeLock contract
+        _grantRole(bytes4(keccak256("setDelay(uint32)")), address(this));
+
+        // Granting roles (queue, cancel, execute, setDelay) must now be executed through this TimeLock contract
+        _grantRole(ROOT, address(this));
+        _revokeRole(ROOT, msg.sender);
+    }
+
+    /// @dev Change the delay for queueing and executing transactions
+    function setDelay(uint32 delay_) external auth {
+        require(delay_ >= MINIMUM_DELAY, "Must exceed minimum delay.");
+        require(delay_ <= MAXIMUM_DELAY, "Must not exceed maximum delay.");
+        delay = delay_;
+
+        emit DelaySet(delay);
+    }
+
+    /// @dev Schedule a transaction batch for execution between `eta` and `eta + GRACE_PERIOD`
+    function queue(address[] memory targets, bytes[] memory data, uint32 eta)
+        external auth returns (bytes32[] memory txHashes)
+    {
+        require(targets.length == data.length, "Mismatched inputs");
+        require(eta >= uint32(block.timestamp) + delay, "Must satisfy delay.");
+
+        txHashes = new bytes32[](targets.length);
+        for (uint256 i = 0; i < targets.length; i++){
+            bytes32 txHash = keccak256(abi.encode(targets[i], data[i], i, targets.length, eta));
+            queued[txHash] = true;
+            emit TransactionQueued(txHash, targets[i], data[i], i, targets.length, eta);
+        }
+    }
+
+    /// @dev Cancel a scheduled  transaction batch
+    function cancel(address[] memory targets, bytes[] memory data, uint32 eta)
+        external auth
+    {
+        require(targets.length == data.length, "Mismatched inputs");
+        for (uint256 i = 0; i < targets.length; i++){
+            bytes32 txHash = keccak256(abi.encode(targets[i], data[i], i, targets.length, eta));
+            queued[txHash] = false;
+            emit TransactionCancelled(txHash, targets[i], data[i], i, targets.length, eta);
+        }
+    }
+
+    /// @dev Execute a transaction batch
+    function execute(address[] memory targets, bytes[] memory data, uint32 eta)
+        external auth returns (bytes[] memory results)
+    {
+        require(targets.length == data.length, "Mismatched inputs");
+        require(uint32(block.timestamp) >= eta, "Time lock not reached.");
+        require(uint32(block.timestamp) <= eta + GRACE_PERIOD, "Transaction is stale.");
+
+        results = new bytes[](targets.length);
+        for (uint256 i = 0; i < targets.length; i++){
+            bytes32 txHash = keccak256(abi.encode(targets[i], data[i], i, targets.length, eta));
+            require(queued[txHash] == true, "Transaction hasn't been queued.");
+            (bool success, bytes memory result) = targets[i].call(data[i]);
+            if (!success) revert(RevertMsgExtractor.getRevertMsg(result));
+            results[i] = result;
+            queued[txHash] = false;
+            emit TransactionExecuted(txHash, targets[i], data[i], i, targets.length, eta);
+        }
+    }
+}

--- a/contracts/utils/TimeLock.sol
+++ b/contracts/utils/TimeLock.sol
@@ -27,13 +27,13 @@ contract TimeLock is ITimeLock, AccessControl {
     uint32 public delay;
     mapping (bytes32 => State) public transactions;
 
-    constructor() AccessControl() {
+    constructor(address governor) AccessControl() {
         delay = MINIMUM_DELAY;
 
         // msg.sender can schedule, cancel, and execute transactions
-        _grantRole(ITimeLock.schedule.selector, msg.sender); // bytes4(keccak256("schedule(address[],bytes[],uint32)"))
-        _grantRole(ITimeLock.cancel.selector, msg.sender); // bytes4(keccak256("cancel(address[],bytes[],uint32)"))
-        _grantRole(ITimeLock.execute.selector, msg.sender); // bytes4(keccak256("execute(address[],bytes[],uint32)"))
+        _grantRole(ITimeLock.schedule.selector, governor); // bytes4(keccak256("schedule(address[],bytes[],uint32)"))
+        _grantRole(ITimeLock.cancel.selector, governor); // bytes4(keccak256("cancel(address[],bytes[],uint32)"))
+        _grantRole(ITimeLock.execute.selector, governor); // bytes4(keccak256("execute(address[],bytes[],uint32)"))
 
         // Changing the delay must now be executed through this TimeLock contract
         _grantRole(ITimeLock.setDelay.selector, address(this)); // bytes4(keccak256("setDelay(uint32)"))

--- a/contracts/utils/TimeLock.sol
+++ b/contracts/utils/TimeLock.sol
@@ -58,8 +58,8 @@ contract TimeLock is ITimeLock, AccessControl {
     {
         require(targets.length == data.length, "Mismatched inputs");
         require(eta >= uint32(block.timestamp) + delay, "Must satisfy delay.");
-        
         txHash = keccak256(abi.encode(targets, data, eta));
+        require(transactions[txHash] == State.UNKNOWN, "Transaction not unknown.");
         transactions[txHash] = State.SCHEDULED;
         emit Scheduled(txHash, targets, data, eta);
     }
@@ -70,6 +70,7 @@ contract TimeLock is ITimeLock, AccessControl {
     {
         require(targets.length == data.length, "Mismatched inputs");
         bytes32 txHash = keccak256(abi.encode(targets, data, eta));
+        require(transactions[txHash] == State.SCHEDULED, "Transaction hasn't been scheduled.");
         transactions[txHash] = State.CANCELLED;
         emit Cancelled(txHash, targets, data, eta);
     }
@@ -82,7 +83,7 @@ contract TimeLock is ITimeLock, AccessControl {
         require(uint32(block.timestamp) >= eta, "ETA not reached.");
         require(uint32(block.timestamp) <= eta + GRACE_PERIOD, "Transaction is stale.");
         bytes32 txHash = keccak256(abi.encode(targets, data, eta));
-        require(transactions[txHash] == State.SCHEDULED, "Transaction hasn't been transactions.");
+        require(transactions[txHash] == State.SCHEDULED, "Transaction hasn't been scheduled.");
         transactions[txHash] = State.EXECUTED;
 
         results = new bytes[](targets.length);

--- a/contracts/utils/TimeLock.sol
+++ b/contracts/utils/TimeLock.sol
@@ -27,13 +27,13 @@ contract TimeLock is ITimeLock, AccessControl {
     uint32 public delay;
     mapping (bytes32 => State) public transactions;
 
-    constructor(address governor) AccessControl() {
+    constructor(address scheduler, address executor) AccessControl() {
         delay = MINIMUM_DELAY;
 
         // msg.sender can schedule, cancel, and execute transactions
-        _grantRole(ITimeLock.schedule.selector, governor); // bytes4(keccak256("schedule(address[],bytes[],uint32)"))
-        _grantRole(ITimeLock.cancel.selector, governor); // bytes4(keccak256("cancel(address[],bytes[],uint32)"))
-        _grantRole(ITimeLock.execute.selector, governor); // bytes4(keccak256("execute(address[],bytes[],uint32)"))
+        _grantRole(ITimeLock.schedule.selector, scheduler); // bytes4(keccak256("schedule(address[],bytes[],uint32)"))
+        _grantRole(ITimeLock.cancel.selector, scheduler); // bytes4(keccak256("cancel(address[],bytes[],uint32)"))
+        _grantRole(ITimeLock.execute.selector, executor); // bytes4(keccak256("execute(address[],bytes[],uint32)"))
 
         // Changing the delay must now be executed through this TimeLock contract
         _grantRole(ITimeLock.setDelay.selector, address(this)); // bytes4(keccak256("setDelay(uint32)"))
@@ -91,7 +91,7 @@ contract TimeLock is ITimeLock, AccessControl {
             (bool success, bytes memory result) = targets[i].call(data[i]);
             if (!success) revert(RevertMsgExtractor.getRevertMsg(result));
             results[i] = result;
-            emit Executed(txHash, targets, data, eta);
         }
+        emit Executed(txHash, targets, data, eta);
     }
 }

--- a/contracts/utils/TimeLock.sol
+++ b/contracts/utils/TimeLock.sol
@@ -5,16 +5,22 @@ pragma solidity ^0.8.0;
 import "../access/AccessControl.sol";
 import "./RevertMsgExtractor.sol";
 
+interface ITimeLock {
+    function setDelay(uint32 delay_) external;
+    function queue(address[] memory targets, bytes[] memory data, uint32 eta) external returns (bytes32 txHash);
+    function cancel(address[] memory targets, bytes[] memory data, uint32 eta) external;
+    function execute(address[] memory targets, bytes[] memory data, uint32 eta) external returns (bytes[] memory results);
+}
 
-contract TimeLock is AccessControl {
+contract TimeLock is ITimeLock, AccessControl {
     uint32 public constant GRACE_PERIOD = 14 days;
     uint32 public constant MINIMUM_DELAY = 2 days;
     uint32 public constant MAXIMUM_DELAY = 30 days;
 
     event DelaySet(uint32 indexed delay);
-    event Cancelled(bytes32 indexed hash, address[] indexed targets, bytes[] data, uint32 eta);
-    event Executed(bytes32 indexed hash, address[] indexed targets, bytes[] data, uint32 eta);
-    event Queued(bytes32 indexed hash, address[] indexed targets, bytes[] data, uint32 eta);
+    event Cancelled(bytes32 indexed txHash, address[] indexed targets, bytes[] data, uint32 eta);
+    event Executed(bytes32 indexed txHash, address[] indexed targets, bytes[] data, uint32 eta);
+    event Queued(bytes32 indexed txHash, address[] indexed targets, bytes[] data, uint32 eta);
 
     uint32 public delay;
     mapping (bytes32 => bool) public queued;
@@ -23,12 +29,12 @@ contract TimeLock is AccessControl {
         delay = MINIMUM_DELAY;
 
         // msg.sender can queue, cancel, and execute transactions
-        _grantRole(bytes4(keccak256("queue(address[],bytes[],uint32)")), msg.sender);
-        _grantRole(bytes4(keccak256("cancel(address[],bytes[],uint32)")), msg.sender);
-        _grantRole(bytes4(keccak256("execute(address[],bytes[],uint32)")), msg.sender);
+        _grantRole(ITimeLock.queue.selector, msg.sender); // bytes4(keccak256("queue(address[],bytes[],uint32)"))
+        _grantRole(ITimeLock.cancel.selector, msg.sender); // bytes4(keccak256("cancel(address[],bytes[],uint32)"))
+        _grantRole(ITimeLock.execute.selector, msg.sender); // bytes4(keccak256("execute(address[],bytes[],uint32)"))
 
         // Changing the delay must now be executed through this TimeLock contract
-        _grantRole(bytes4(keccak256("setDelay(uint32)")), address(this));
+        _grantRole(ITimeLock.setDelay.selector, address(this)); // bytes4(keccak256("setDelay(uint32)"))
 
         // Granting roles (queue, cancel, execute, setDelay) must now be executed through this TimeLock contract
         _grantRole(ROOT, address(this));
@@ -36,7 +42,7 @@ contract TimeLock is AccessControl {
     }
 
     /// @dev Change the delay for queueing and executing transactions
-    function setDelay(uint32 delay_) external auth {
+    function setDelay(uint32 delay_) external override auth {
         require(delay_ >= MINIMUM_DELAY, "Must exceed minimum delay.");
         require(delay_ <= MAXIMUM_DELAY, "Must not exceed maximum delay.");
         delay = delay_;
@@ -46,43 +52,43 @@ contract TimeLock is AccessControl {
 
     /// @dev Schedule a transaction batch for execution between `eta` and `eta + GRACE_PERIOD`
     function queue(address[] memory targets, bytes[] memory data, uint32 eta)
-        external auth returns (bytes32 hash)
+        external override auth returns (bytes32 txHash)
     {
         require(targets.length == data.length, "Mismatched inputs");
         require(eta >= uint32(block.timestamp) + delay, "Must satisfy delay.");
         
-        hash = keccak256(abi.encode(targets, data, eta));
-        queued[hash] = true;
-        emit Queued(hash, targets, data, eta);
+        txHash = keccak256(abi.encode(targets, data, eta));
+        queued[txHash] = true;
+        emit Queued(txHash, targets, data, eta);
     }
 
     /// @dev Cancel a scheduled  transaction batch
     function cancel(address[] memory targets, bytes[] memory data, uint32 eta)
-        external auth
+        external override auth
     {
         require(targets.length == data.length, "Mismatched inputs");
-        bytes32 hash = keccak256(abi.encode(targets, data, eta));
-        queued[hash] = false;
-        emit Cancelled(hash, targets, data, eta);
+        bytes32 txHash = keccak256(abi.encode(targets, data, eta));
+        queued[txHash] = false;
+        emit Cancelled(txHash, targets, data, eta);
     }
 
     /// @dev Execute a transaction batch
     function execute(address[] memory targets, bytes[] memory data, uint32 eta)
-        external auth returns (bytes[] memory results)
+        external override auth returns (bytes[] memory results)
     {
         require(targets.length == data.length, "Mismatched inputs");
-        require(uint32(block.timestamp) >= eta, "Time lock not reached.");
+        require(uint32(block.timestamp) >= eta, "ETA not reached.");
         require(uint32(block.timestamp) <= eta + GRACE_PERIOD, "Transaction is stale.");
-        bytes32 hash = keccak256(abi.encode(targets, data, eta));
-        require(queued[hash] == true, "Transaction hasn't been queued.");
-        queued[hash] = false;
+        bytes32 txHash = keccak256(abi.encode(targets, data, eta));
+        require(queued[txHash] == true, "Transaction hasn't been queued.");
+        queued[txHash] = false;
 
         results = new bytes[](targets.length);
         for (uint256 i = 0; i < targets.length; i++){
             (bool success, bytes memory result) = targets[i].call(data[i]);
             if (!success) revert(RevertMsgExtractor.getRevertMsg(result));
             results[i] = result;
-            emit Executed(hash, targets, data, eta);
+            emit Executed(txHash, targets, data, eta);
         }
     }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@yield-protocol/utils-v2",
-  "version": "2.2.15",
+  "version": "2.2.17",
   "description": "Yield v2 utility contracts",
   "author": "Yield Inc.",
   "files": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@yield-protocol/utils-v2",
-  "version": "2.2.12",
+  "version": "2.2.13",
   "description": "Yield v2 utility contracts",
   "author": "Yield Inc.",
   "files": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@yield-protocol/utils-v2",
-  "version": "2.2.11",
+  "version": "2.2.12",
   "description": "Yield v2 utility contracts",
   "author": "Yield Inc.",
   "files": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@yield-protocol/utils-v2",
-  "version": "2.2.13",
+  "version": "2.2.14",
   "description": "Yield v2 utility contracts",
   "author": "Yield Inc.",
   "files": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@yield-protocol/utils-v2",
-  "version": "2.2.10",
+  "version": "2.2.11",
   "description": "Yield v2 utility contracts",
   "author": "Yield Inc.",
   "files": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@yield-protocol/utils-v2",
-  "version": "2.2.14",
+  "version": "2.2.15",
   "description": "Yield v2 utility contracts",
   "author": "Yield Inc.",
   "files": [

--- a/test/005_timelock.ts
+++ b/test/005_timelock.ts
@@ -82,6 +82,13 @@ describe('TimeLock', async function () {
     await expect(timelock.schedule(targets, data, eta)).to.be.revertedWith('Must satisfy delay')
   })
 
+  it('doesn\'t allow to cancel if not scheduled', async () => {
+    const targets = [target1.address]
+    const data = [target1.interface.encodeFunctionData('mint', [owner, 1])]
+    const eta = timestamp
+    await expect(timelock.cancel(targets, data, eta)).to.be.revertedWith('Transaction hasn\'t been scheduled.')
+  })
+
   it('doesn\'t allow to execute before eta', async () => {
     const targets = [target1.address]
     const data = [target1.interface.encodeFunctionData('mint', [owner, 1])]
@@ -96,11 +103,11 @@ describe('TimeLock', async function () {
     await expect(timelock.execute(targets, data, eta)).to.be.revertedWith('Transaction is stale')
   })
 
-  it('doesn\'t allow to execute if not transactions', async () => {
+  it('doesn\'t allow to execute if not scheduled', async () => {
     const targets = [target1.address]
     const data = [target1.interface.encodeFunctionData('mint', [owner, 1])]
     const eta = timestamp
-    await expect(timelock.execute(targets, data, eta)).to.be.revertedWith('Transaction hasn\'t been transactions.')
+    await expect(timelock.execute(targets, data, eta)).to.be.revertedWith('Transaction hasn\'t been scheduled.')
   })
 
   it('queues a transaction', async () => {
@@ -115,7 +122,7 @@ describe('TimeLock', async function () {
     expect(await timelock.transactions(txHash)).to.equal(state.SCHEDULED)
   })
 
-  describe('with a transactions transaction', async () => {
+  describe('with a scheduled transaction', async () => {
     let snapshotId: string
     let timestamp: number
     let targets: string[]

--- a/test/005_timelock.ts
+++ b/test/005_timelock.ts
@@ -1,179 +1,243 @@
-import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/dist/src/signer-with-address'
+import { SignerWithAddress } from "@nomiclabs/hardhat-ethers/dist/src/signer-with-address";
 
 import { id } from "../src/index";
 
-import ERC20MockArtifact from '../artifacts/contracts/mocks/ERC20Mock.sol/ERC20Mock.json'
-import TimeLockArtifact from '../artifacts/contracts/utils/TimeLock.sol/TimeLock.json'
-import { ERC20Mock as ERC20 } from '../typechain/ERC20Mock'
-import { TimeLock } from '../typechain/TimeLock'
+import ERC20MockArtifact from "../artifacts/contracts/mocks/ERC20Mock.sol/ERC20Mock.json";
+import TimeLockArtifact from "../artifacts/contracts/utils/TimeLock.sol/TimeLock.json";
+import { ERC20Mock as ERC20 } from "../typechain/ERC20Mock";
+import { TimeLock } from "../typechain/TimeLock";
 
-import { BigNumber } from 'ethers'
+import { BigNumber } from "ethers";
 
-import { ethers, waffle } from 'hardhat'
-import { expect } from 'chai'
-const { deployContract, loadFixture } = waffle
+import { ethers, waffle } from "hardhat";
+import { expect } from "chai";
+const { deployContract, loadFixture } = waffle;
 
-describe('TimeLock', async function () {
-  this.timeout(0)
+describe("TimeLock", async function () {
+  this.timeout(0);
 
-  let ownerAcc: SignerWithAddress
-  let owner: string
-  let user1: string
-  let user1Acc: SignerWithAddress
-  let user2: string
-  let user2Acc: SignerWithAddress
+  let schedulerAcc: SignerWithAddress;
+  let scheduler: string;
+  let executorAcc: SignerWithAddress;
+  let executor: string;
 
-  let target1: ERC20
-  let target2: ERC20
-  let timelock: TimeLock
+  let target1: ERC20;
+  let target2: ERC20;
+  let timelock: TimeLock;
 
-  let timestamp: number
-  let resetChain: number
+  let timestamp: number;
+  let resetChain: number;
 
   const state = {
     UNKNOWN: 0,
     SCHEDULED: 1,
-    CANCELLED: 2, 
+    CANCELLED: 2,
     EXECUTED: 3,
-  }
+  };
 
   before(async () => {
-    resetChain = await ethers.provider.send('evm_snapshot', [])
-    const signers = await ethers.getSigners()
-    ownerAcc = signers[0]
-    owner = ownerAcc.address
-    user1Acc = signers[1]
-    user1 = user1Acc.address
-    user2Acc = signers[2]
-    user2 = user2Acc.address
-  })
+    resetChain = await ethers.provider.send("evm_snapshot", []);
+    const signers = await ethers.getSigners();
+    schedulerAcc = signers[0];
+    scheduler = schedulerAcc.address;
+    executorAcc = signers[1];
+    executor = executorAcc.address;
+  });
 
   after(async () => {
-    await ethers.provider.send('evm_revert', [resetChain])
-  })
+    await ethers.provider.send("evm_revert", [resetChain]);
+  });
 
   beforeEach(async () => {
-    target1 = (await deployContract(ownerAcc, ERC20MockArtifact, ['Target1', 'TG1'])) as ERC20
-    target2 = (await deployContract(ownerAcc, ERC20MockArtifact, ['Target2', 'TG2'])) as ERC20
-    timelock = (await deployContract(ownerAcc, TimeLockArtifact, [owner])) as TimeLock
-    ;({ timestamp } = await ethers.provider.getBlock('latest'))
-  })
+    target1 = (await deployContract(schedulerAcc, ERC20MockArtifact, [
+      "Target1",
+      "TG1",
+    ])) as ERC20;
+    target2 = (await deployContract(schedulerAcc, ERC20MockArtifact, [
+      "Target2",
+      "TG2",
+    ])) as ERC20;
+    timelock = (await deployContract(schedulerAcc, TimeLockArtifact, [
+      scheduler,
+      executor,
+    ])) as TimeLock;
+    ({ timestamp } = await ethers.provider.getBlock("latest"));
+  });
 
-  it('doesn\'t allow governance changes to owner', async () => {
-    await expect(timelock.setDelay(0)).to.be.revertedWith('Access denied')
-    await expect(timelock.grantRole('0x00000000', owner)).to.be.revertedWith('Only admin')
-    await expect(timelock.grantRole(id('schedule(address[],bytes[],uint32)'), user1)).to.be.revertedWith('Only admin')
-    await expect(timelock.revokeRole(id('schedule(address[],bytes[],uint32)'), owner)).to.be.revertedWith('Only admin')
-  })
+  it("doesn't allow governance changes to scheduler", async () => {
+    await expect(timelock.setDelay(0)).to.be.revertedWith("Access denied");
+    await expect(
+      timelock.grantRole("0x00000000", scheduler)
+    ).to.be.revertedWith("Only admin");
+    await expect(
+      timelock.grantRole(id("schedule(address[],bytes[],uint32)"), executor)
+    ).to.be.revertedWith("Only admin");
+    await expect(
+      timelock.revokeRole(id("schedule(address[],bytes[],uint32)"), scheduler)
+    ).to.be.revertedWith("Only admin");
+  });
 
-  it('doesn\'t allow mismatched inputs', async () => {
-    const targets = [target1.address, target2.address]
-    const data = [target1.interface.encodeFunctionData('mint', [owner, 1])]
-    const eta = timestamp + await timelock.delay()
-    await expect(timelock.schedule(targets, data, eta)).to.be.revertedWith('Mismatched inputs')
-    await expect(timelock.cancel(targets, data, eta)).to.be.revertedWith('Mismatched inputs')
-    await expect(timelock.execute(targets, data, eta)).to.be.revertedWith('Mismatched inputs')
-  })
+  it("doesn't allow mismatched inputs", async () => {
+    const targets = [target1.address, target2.address];
+    const data = [target1.interface.encodeFunctionData("mint", [scheduler, 1])];
+    const eta = timestamp + (await timelock.delay());
+    await expect(
+      timelock.connect(schedulerAcc).schedule(targets, data, eta)
+    ).to.be.revertedWith("Mismatched inputs");
+    await expect(
+      timelock.connect(schedulerAcc).cancel(targets, data, eta)
+    ).to.be.revertedWith("Mismatched inputs");
+    await expect(
+      timelock.connect(executorAcc).execute(targets, data, eta)
+    ).to.be.revertedWith("Mismatched inputs");
+  });
 
-  it('doesn\'t allow to schedule for execution before `delay()`', async () => {
-    const targets = [target1.address]
-    const data = [target1.interface.encodeFunctionData('mint', [owner, 1])]
-    const eta = timestamp
-    await expect(timelock.schedule(targets, data, eta)).to.be.revertedWith('Must satisfy delay')
-  })
+  it("only the scheduler can schedule", async () => {
+    const targets = [target1.address];
+    const data = [target1.interface.encodeFunctionData("mint", [scheduler, 1])];
+    const eta = timestamp;
+    await expect(
+      timelock.connect(executorAcc).schedule(targets, data, eta)
+    ).to.be.revertedWith("Access denied");
+  });
 
-  it('doesn\'t allow to cancel if not scheduled', async () => {
-    const targets = [target1.address]
-    const data = [target1.interface.encodeFunctionData('mint', [owner, 1])]
-    const eta = timestamp
-    await expect(timelock.cancel(targets, data, eta)).to.be.revertedWith('Transaction hasn\'t been scheduled.')
-  })
+  it("doesn't allow to schedule for execution before `delay()`", async () => {
+    const targets = [target1.address];
+    const data = [target1.interface.encodeFunctionData("mint", [scheduler, 1])];
+    const eta = timestamp;
+    await expect(
+      timelock.connect(schedulerAcc).schedule(targets, data, eta)
+    ).to.be.revertedWith("Must satisfy delay");
+  });
 
-  it('doesn\'t allow to execute before eta', async () => {
-    const targets = [target1.address]
-    const data = [target1.interface.encodeFunctionData('mint', [owner, 1])]
-    const eta = timestamp + 100
-    await expect(timelock.execute(targets, data, eta)).to.be.revertedWith('ETA not reached')
-  })
+  it("only the scheduler can cancel", async () => {
+    const targets = [target1.address];
+    const data = [target1.interface.encodeFunctionData("mint", [scheduler, 1])];
+    const eta = timestamp;
+    await expect(
+      timelock.connect(executorAcc).cancel(targets, data, eta)
+    ).to.be.revertedWith("Access denied");
+  });
 
-  it('doesn\'t allow to execute after grace period', async () => {
-    const targets = [target1.address]
-    const data = [target1.interface.encodeFunctionData('mint', [owner, 1])]
-    const eta = timestamp - (await timelock.GRACE_PERIOD())
-    await expect(timelock.execute(targets, data, eta)).to.be.revertedWith('Transaction is stale')
-  })
+  it("doesn't allow to cancel if not scheduled", async () => {
+    const targets = [target1.address];
+    const data = [target1.interface.encodeFunctionData("mint", [scheduler, 1])];
+    const eta = timestamp;
+    await expect(
+      timelock.connect(schedulerAcc).cancel(targets, data, eta)
+    ).to.be.revertedWith("Transaction hasn't been scheduled.");
+  });
 
-  it('doesn\'t allow to execute if not scheduled', async () => {
-    const targets = [target1.address]
-    const data = [target1.interface.encodeFunctionData('mint', [owner, 1])]
-    const eta = timestamp
-    await expect(timelock.execute(targets, data, eta)).to.be.revertedWith('Transaction hasn\'t been scheduled.')
-  })
+  it("only the executor can execute", async () => {
+    const targets = [target1.address];
+    const data = [target1.interface.encodeFunctionData("mint", [scheduler, 1])];
+    const eta = timestamp;
+    await expect(
+      timelock
+        .connect(schedulerAcc)
+        .connect(schedulerAcc)
+        .execute(targets, data, eta)
+    ).to.be.revertedWith("Access denied");
+  });
 
-  it('queues a transaction', async () => {
-    const targets = [target1.address]
-    const data = [target1.interface.encodeFunctionData('mint', [owner, 1])]
-    const eta = timestamp + await timelock.delay() + 100
-    const txHash = await timelock.callStatic.schedule(targets, data, eta)
+  it("doesn't allow to execute before eta", async () => {
+    const targets = [target1.address];
+    const data = [target1.interface.encodeFunctionData("mint", [scheduler, 1])];
+    const eta = timestamp + 100;
+    await expect(
+      timelock.connect(executorAcc).execute(targets, data, eta)
+    ).to.be.revertedWith("ETA not reached");
+  });
 
-    await expect(await timelock.schedule(targets, data, eta))
-      .to.emit(timelock, 'Scheduled')
-//      .withArgs(txHash, targets, data, eta)
-    expect(await timelock.transactions(txHash)).to.equal(state.SCHEDULED)
-  })
+  it("doesn't allow to execute after grace period", async () => {
+    const targets = [target1.address];
+    const data = [target1.interface.encodeFunctionData("mint", [scheduler, 1])];
+    const eta = timestamp - (await timelock.GRACE_PERIOD());
+    await expect(
+      timelock.connect(executorAcc).execute(targets, data, eta)
+    ).to.be.revertedWith("Transaction is stale");
+  });
 
-  describe('with a scheduled transaction', async () => {
-    let snapshotId: string
-    let timestamp: number
-    let targets: string[]
-    let data: string[]
-    let eta: number
-    let txHash: string
+  it("doesn't allow to execute if not scheduled", async () => {
+    const targets = [target1.address];
+    const data = [target1.interface.encodeFunctionData("mint", [scheduler, 1])];
+    const eta = timestamp;
+    await expect(
+      timelock.connect(executorAcc).execute(targets, data, eta)
+    ).to.be.revertedWith("Transaction hasn't been scheduled.");
+  });
+
+  it("queues a transaction", async () => {
+    const targets = [target1.address];
+    const data = [target1.interface.encodeFunctionData("mint", [scheduler, 1])];
+    const eta = timestamp + (await timelock.delay()) + 100;
+    const txHash = await timelock
+      .connect(schedulerAcc)
+      .callStatic.schedule(targets, data, eta);
+
+    await expect(
+      await timelock.connect(schedulerAcc).schedule(targets, data, eta)
+    ).to.emit(timelock, "Scheduled");
+    //      .withArgs(txHash, targets, data, eta)
+    expect(await timelock.transactions(txHash)).to.equal(state.SCHEDULED);
+  });
+
+  describe("with a scheduled transaction", async () => {
+    let snapshotId: string;
+    let timestamp: number;
+    let targets: string[];
+    let data: string[];
+    let eta: number;
+    let txHash: string;
 
     beforeEach(async () => {
-      ;({ timestamp } = await ethers.provider.getBlock('latest'))
-      targets = [
-        target1.address,
-        target2.address,
-      ]
+      ({ timestamp } = await ethers.provider.getBlock("latest"));
+      targets = [target1.address, target2.address];
       data = [
-        target1.interface.encodeFunctionData('mint', [owner, 1]),
-        target2.interface.encodeFunctionData('approve', [owner, 1]),
-      ]
-      eta = timestamp + await timelock.delay() + 100
-      txHash = await timelock.callStatic.schedule(targets, data, eta)
-      await timelock.schedule(targets, data, eta)
-    })
+        target1.interface.encodeFunctionData("mint", [scheduler, 1]),
+        target2.interface.encodeFunctionData("approve", [scheduler, 1]),
+      ];
+      eta = timestamp + (await timelock.delay()) + 100;
+      txHash = await timelock
+        .connect(schedulerAcc)
+        .callStatic.schedule(targets, data, eta);
+      await timelock.connect(schedulerAcc).schedule(targets, data, eta);
+    });
 
-    it('cancels a transaction', async () => {
-      await expect(await timelock.cancel(targets, data, eta))
-        .to.emit(timelock, 'Cancelled')
-//        .withArgs(txHash, targets, data, eta)
-      expect(await timelock.transactions(txHash)).to.equal(state.CANCELLED)
-    })
+    it("cancels a transaction", async () => {
+      await expect(
+        await timelock.connect(schedulerAcc).cancel(targets, data, eta)
+      ).to.emit(timelock, "Cancelled");
+      //        .withArgs(txHash, targets, data, eta)
+      expect(await timelock.transactions(txHash)).to.equal(state.CANCELLED);
+    });
 
-    describe('once the eta arrives', async () => {
+    describe("once the eta arrives", async () => {
       beforeEach(async () => {
-        snapshotId = await ethers.provider.send('evm_snapshot', [])
-        await ethers.provider.send('evm_mine', [eta])
-      })
+        snapshotId = await ethers.provider.send("evm_snapshot", []);
+        await ethers.provider.send("evm_mine", [eta]);
+      });
 
       afterEach(async () => {
-        await ethers.provider.send('evm_revert', [snapshotId])
-      })
+        await ethers.provider.send("evm_revert", [snapshotId]);
+      });
 
-      it('executes a transaction', async () => {
-        await expect(await timelock.execute(targets, data, eta))
-          .to.emit(timelock, 'Executed')
-//          .withArgs(txHash, targets, data, eta)
-          .to.emit(target1, 'Transfer')
-//          .withArgs(null, owner, 1)
-          .to.emit(target2, 'Approval')
-//          .withArgs(owner, owner, 1)
-        expect(await timelock.transactions(txHash)).to.equal(state.EXECUTED)
-        expect(await target1.balanceOf(owner)).to.equal(1)
-        expect(await target2.allowance(timelock.address, owner)).to.equal(1)
-      })
-    })
-  })
-})
+      it("executes a transaction", async () => {
+        await expect(
+          await timelock.connect(executorAcc).execute(targets, data, eta)
+        )
+          .to.emit(timelock, "Executed")
+          //          .withArgs(txHash, targets, data, eta)
+          .to.emit(target1, "Transfer")
+          //          .withArgs(null, scheduler, 1)
+          .to.emit(target2, "Approval");
+        //          .withArgs(scheduler, scheduler, 1)
+        expect(await timelock.transactions(txHash)).to.equal(state.EXECUTED);
+        expect(await target1.balanceOf(scheduler)).to.equal(1);
+        expect(await target2.allowance(timelock.address, scheduler)).to.equal(
+          1
+        );
+      });
+    });
+  });
+});

--- a/test/005_timelock.ts
+++ b/test/005_timelock.ts
@@ -55,7 +55,7 @@ describe('TimeLock', async function () {
   beforeEach(async () => {
     target1 = (await deployContract(ownerAcc, ERC20MockArtifact, ['Target1', 'TG1'])) as ERC20
     target2 = (await deployContract(ownerAcc, ERC20MockArtifact, ['Target2', 'TG2'])) as ERC20
-    timelock = (await deployContract(ownerAcc, TimeLockArtifact, [])) as TimeLock
+    timelock = (await deployContract(ownerAcc, TimeLockArtifact, [owner])) as TimeLock
     ;({ timestamp } = await ethers.provider.getBlock('latest'))
   })
 

--- a/test/005_timelock.ts
+++ b/test/005_timelock.ts
@@ -1,0 +1,165 @@
+import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/dist/src/signer-with-address'
+
+import { id } from "../src/index";
+
+import ERC20MockArtifact from '../artifacts/contracts/mocks/ERC20Mock.sol/ERC20Mock.json'
+import TimeLockArtifact from '../artifacts/contracts/utils/TimeLock.sol/TimeLock.json'
+import { ERC20Mock as ERC20 } from '../typechain/ERC20Mock'
+import { TimeLock } from '../typechain/TimeLock'
+
+import { BigNumber } from 'ethers'
+
+import { ethers, waffle } from 'hardhat'
+import { expect } from 'chai'
+const { deployContract, loadFixture } = waffle
+
+describe('TimeLock', async function () {
+  this.timeout(0)
+
+  let ownerAcc: SignerWithAddress
+  let owner: string
+  let user1: string
+  let user1Acc: SignerWithAddress
+  let user2: string
+  let user2Acc: SignerWithAddress
+
+  let target1: ERC20
+  let target2: ERC20
+  let timelock: TimeLock
+
+  let timestamp: number
+  let resetChain: number
+
+  before(async () => {
+    resetChain = await ethers.provider.send('evm_snapshot', [])
+    const signers = await ethers.getSigners()
+    ownerAcc = signers[0]
+    owner = ownerAcc.address
+    user1Acc = signers[1]
+    user1 = user1Acc.address
+    user2Acc = signers[2]
+    user2 = user2Acc.address
+  })
+
+  after(async () => {
+    await ethers.provider.send('evm_revert', [resetChain])
+  })
+
+  beforeEach(async () => {
+    target1 = (await deployContract(ownerAcc, ERC20MockArtifact, ['Target1', 'TG1'])) as ERC20
+    target2 = (await deployContract(ownerAcc, ERC20MockArtifact, ['Target2', 'TG2'])) as ERC20
+    timelock = (await deployContract(ownerAcc, TimeLockArtifact, [])) as TimeLock
+    ;({ timestamp } = await ethers.provider.getBlock('latest'))
+  })
+
+  it('doesn\'t allow governance changes to owner', async () => {
+    await expect(timelock.setDelay(0)).to.be.revertedWith('Access denied')
+    await expect(timelock.grantRole('0x00000000', owner)).to.be.revertedWith('Only admin')
+    await expect(timelock.grantRole(id('queue(address[],bytes[],uint32)'), user1)).to.be.revertedWith('Only admin')
+    await expect(timelock.revokeRole(id('queue(address[],bytes[],uint32)'), owner)).to.be.revertedWith('Only admin')
+  })
+
+  it('doesn\'t allow mismatched inputs', async () => {
+    const targets = [target1.address, target2.address]
+    const data = [target1.interface.encodeFunctionData('mint', [owner, 1])]
+    const eta = timestamp + await timelock.delay()
+    await expect(timelock.queue(targets, data, eta)).to.be.revertedWith('Mismatched inputs')
+    await expect(timelock.cancel(targets, data, eta)).to.be.revertedWith('Mismatched inputs')
+    await expect(timelock.execute(targets, data, eta)).to.be.revertedWith('Mismatched inputs')
+  })
+
+  it('doesn\'t allow to queue for execution before `delay()`', async () => {
+    const targets = [target1.address]
+    const data = [target1.interface.encodeFunctionData('mint', [owner, 1])]
+    const eta = timestamp
+    await expect(timelock.queue(targets, data, eta)).to.be.revertedWith('Must satisfy delay')
+  })
+
+  it('doesn\'t allow to execute before eta', async () => {
+    const targets = [target1.address]
+    const data = [target1.interface.encodeFunctionData('mint', [owner, 1])]
+    const eta = timestamp + 100
+    await expect(timelock.execute(targets, data, eta)).to.be.revertedWith('ETA not reached')
+  })
+
+  it('doesn\'t allow to execute after grace period', async () => {
+    const targets = [target1.address]
+    const data = [target1.interface.encodeFunctionData('mint', [owner, 1])]
+    const eta = timestamp - (await timelock.GRACE_PERIOD())
+    await expect(timelock.execute(targets, data, eta)).to.be.revertedWith('Transaction is stale')
+  })
+
+  it('doesn\'t allow to execute if not queued', async () => {
+    const targets = [target1.address]
+    const data = [target1.interface.encodeFunctionData('mint', [owner, 1])]
+    const eta = timestamp
+    await expect(timelock.execute(targets, data, eta)).to.be.revertedWith('Transaction hasn\'t been queued.')
+  })
+
+  it('queues a transaction', async () => {
+    const targets = [target1.address]
+    const data = [target1.interface.encodeFunctionData('mint', [owner, 1])]
+    const eta = timestamp + await timelock.delay() + 100
+    const txHash = await timelock.callStatic.queue(targets, data, eta)
+
+    await expect(await timelock.queue(targets, data, eta))
+      .to.emit(timelock, 'Queued')
+//      .withArgs(txHash, targets, data, eta)
+    expect(await timelock.queued(txHash)).to.be.true
+  })
+
+  describe('with a queued transaction', async () => {
+    let snapshotId: string
+    let timestamp: number
+    let targets: string[]
+    let data: string[]
+    let eta: number
+    let txHash: string
+
+    beforeEach(async () => {
+      ;({ timestamp } = await ethers.provider.getBlock('latest'))
+      targets = [
+        target1.address,
+        target2.address,
+      ]
+      data = [
+        target1.interface.encodeFunctionData('mint', [owner, 1]),
+        target2.interface.encodeFunctionData('approve', [owner, 1]),
+      ]
+      eta = timestamp + await timelock.delay() + 100
+      txHash = await timelock.callStatic.queue(targets, data, eta)
+      await timelock.queue(targets, data, eta)
+    })
+
+    it('cancels a transaction', async () => {
+      await expect(await timelock.cancel(targets, data, eta))
+        .to.emit(timelock, 'Cancelled')
+//        .withArgs(txHash, targets, data, eta)
+      expect(await timelock.queued(txHash)).to.be.false
+    })
+
+    describe('once the eta arrives', async () => {
+      beforeEach(async () => {
+        snapshotId = await ethers.provider.send('evm_snapshot', [])
+        await ethers.provider.send('evm_mine', [eta])
+      })
+
+      afterEach(async () => {
+        await ethers.provider.send('evm_revert', [snapshotId])
+      })
+
+      it('executes a transaction', async () => {
+        await expect(await timelock.execute(targets, data, eta))
+          .to.emit(timelock, 'Executed')
+//          .withArgs(txHash, targets, data, eta)
+          .to.emit(target1, 'Transfer')
+//          .withArgs(null, owner, 1)
+          .to.emit(target2, 'Approval')
+//          .withArgs(owner, owner, 1)
+        expect(await timelock.queued(txHash)).to.be.false
+        expect(await target1.balanceOf(owner)).to.equal(1)
+        expect(await target2.allowance(timelock.address, owner)).to.equal(1)
+      })
+    })
+  })
+})


### PR DESCRIPTION
This is [TimeLock.sol from Compound](https://github.com/compound-finance/compound-protocol/blob/master/contracts/Timelock.sol), but using AccessControl.sol, RevertMsgExtractor.sol and a variant of Multicall.sol.

As with the original TimeLock.sol, changing the delay must come from the contract itself and set to delay. Same goes for granting and revoking roles (setDelay, queue, cancel, execute).

Instead of queuing a single call, a batch of them is queued. Using this feature TimeLock.sol can be used as the orchestrator of governance actions. The idea of batching calls in TimeLock.sol was [first executed by OpenZeppelin](https://github.com/OpenZeppelin/openzeppelin-contracts/blob/master/contracts/governance/TimelockController.sol), but this is a much simpler implementation.

To reduce the risk of governance attacks, `schedule` and `cancel` rights are given to one address, while `execute` rights are given to a different one.

Finally, revert messages bubble up as usual.