### PR TITLE
CastBytes32Bytes12

### DIFF
--- a/contracts/cast/CastBytes32Bytes12.sol
+++ b/contracts/cast/CastBytes32Bytes12.sol
@@ -1,0 +1,9 @@
+// SPDX-License-Identifier: BUSL-1.1
+pragma solidity ^0.8.0;
+
+
+library CastBytes32Bytes12 {
+    function b12(bytes32 x) internal pure returns (bytes12 y) {
+        require (bytes32(y = bytes12(x)) == x, "Cast overflow");
+    }
+}


### PR DESCRIPTION
Adds a new library to `yield-utils-v2` for casting values of the type `bytes32` to `bytes12`.