### PR TITLE
allow cancelling proposed and approved proposals

### DIFF
--- a/test/005_timelock.ts
+++ b/test/005_timelock.ts
@@ -109,17 +109,13 @@ describe("Timelock", async function () {
   it("doesn't allow to approve if not proposed", async () => {
     const txHash =
       "0x00004732e64f236e5182740fa5473c496f60cecc294538c44897d62be999d1ed";
-    await expect(timelock.approve(txHash)).to.be.revertedWith(
-      "Not proposed."
-    );
+    await expect(timelock.approve(txHash)).to.be.revertedWith("Not proposed.");
   });
 
   it("doesn't allow to cancel if not proposed", async () => {
     const txHash =
       "0x00004732e64f236e5182740fa5473c496f60cecc294538c44897d62be999d1ed";
-    await expect(timelock.cancel(txHash)).to.be.revertedWith(
-      "Not found."
-    );
+    await expect(timelock.cancel(txHash)).to.be.revertedWith("Not found.");
   });
 
   it("proposes a transaction", async () => {
@@ -201,7 +197,7 @@ describe("Timelock", async function () {
         "Cancelled"
       );
       //        .withArgs(txHash, targets, data, eta)
-      const [state] = await timelock.proposals(txHash)
+      const [state] = await timelock.proposals(txHash);
       expect(state).equal(0);
     });
 
@@ -297,7 +293,7 @@ describe("Timelock", async function () {
           "Cancelled"
         );
         //        .withArgs(txHash, targets, data, eta)
-        const [state] = await timelock.proposals(txHash)
+        const [state] = await timelock.proposals(txHash);
         expect(state).equal(0);
       });
 

--- a/test/005_timelock.ts
+++ b/test/005_timelock.ts
@@ -106,6 +106,22 @@ describe("Timelock", async function () {
     ).to.be.revertedWith("Access denied");
   });
 
+  it("doesn't allow to approve if not proposed", async () => {
+    const txHash =
+      "0x00004732e64f236e5182740fa5473c496f60cecc294538c44897d62be999d1ed";
+    await expect(timelock.approve(txHash)).to.be.revertedWith(
+      "Not proposed."
+    );
+  });
+
+  it("doesn't allow to cancel if not proposed", async () => {
+    const txHash =
+      "0x00004732e64f236e5182740fa5473c496f60cecc294538c44897d62be999d1ed";
+    await expect(timelock.cancel(txHash)).to.be.revertedWith(
+      "Not found."
+    );
+  });
+
   it("proposes a transaction", async () => {
     const functionCalls = [
       {
@@ -170,14 +186,6 @@ describe("Timelock", async function () {
       ).to.be.revertedWith("Access denied");
     });
 
-    it("doesn't allow to approve if not proposed", async () => {
-      const txHash =
-        "0x00004732e64f236e5182740fa5473c496f60cecc294538c44897d62be999d1ed";
-      await expect(timelock.approve(txHash)).to.be.revertedWith(
-        "Not proposed."
-      );
-    });
-
     it("approves a transaction", async () => {
       await expect(await timelock.approve(txHash)).to.emit(
         timelock,
@@ -185,6 +193,16 @@ describe("Timelock", async function () {
       );
       //        .withArgs(txHash, targets, data, eta)
       expect(await timelock.proposals(txHash)).not.equal(0);
+    });
+
+    it("cancels a proposed transaction", async () => {
+      await expect(await timelock.cancel(txHash)).to.emit(
+        timelock,
+        "Cancelled"
+      );
+      //        .withArgs(txHash, targets, data, eta)
+      const [state] = await timelock.proposals(txHash)
+      expect(state).equal(0);
     });
 
     describe("with an approved transaction", async () => {
@@ -271,6 +289,16 @@ describe("Timelock", async function () {
         );
 
         await ethers.provider.send("evm_revert", [snapshotId]);
+      });
+
+      it("cancels an approved transaction", async () => {
+        await expect(await timelock.cancel(txHash)).to.emit(
+          timelock,
+          "Cancelled"
+        );
+        //        .withArgs(txHash, targets, data, eta)
+        const [state] = await timelock.proposals(txHash)
+        expect(state).equal(0);
       });
 
       describe("once the eta arrives", async () => {


### PR DESCRIPTION
The Timelock allows to cancel a proposal that hasn't yet been executed.

In a couple of instances, we've found errors or vulnerabilities in a proposal during the delay period, and that introduces a risk.