### PR TITLE
Send ether using callWithValue

### DIFF
--- a/contracts/utils/Timelock.sol
+++ b/contracts/utils/Timelock.sol
@@ -175,4 +175,15 @@ contract Timelock is ITimelock, AccessControl {
         }
         emit Executed(txHash);
     }
+
+    /// @dev To send Ether with a call, the Timelock must call itself at this function. This avoids
+    /// adding a rarely used `value` in the Call struct
+    function callWithValue(Call calldata functionCall, uint256 value) external returns (bytes memory result) {
+        require(msg.sender == address(this), "Only call from itself");
+        bool success;
+        (success, result) = functionCall.target.call{ value: value }(functionCall.data);
+        if (!success) revert(RevertMsgExtractor.getRevertMsg(result));
+    }
+
+    receive() payable external {}
 }


### PR DESCRIPTION
Allow the Timelock to receive Ether and to call other contracts sending Ether. One of the goals of this change is to avoid adding a `value` parameter to the `Call` struct that then would have to be set all the time, mostly as zero.

Sending Ether in a call is rarely done, so the extra work to do it is worth not inconveniencing users in all other calls.