### PR TITLE
Replace all the `*Repeated` nonsense with a one-liner

### DIFF
--- a/contracts/utils/Timelock.sol
+++ b/contracts/utils/Timelock.sol
@@ -86,6 +86,10 @@ contract Timelock is ITimelock, AccessControl {
     }
 
     /// @dev Propose a transaction batch for execution
+    /// @notice If several identical proposals should be simultaneously lodged, such as for example for
+    /// identical monthly payments to the same contractor, their proposal hash can be made to differ by
+    /// appending to each one a different view function call such as `dai.balanceOf(0xbabe)` and
+    /// `dai.balanceOf(0xbeef)`.
     function propose(Call[] calldata functionCalls)
         external override auth returns (bytes32 txHash)
     {
@@ -141,9 +145,6 @@ contract Timelock is ITimelock, AccessControl {
         }
         emit Executed(txHash);
     }
-
-    /// @dev Add a call to this function to obtain different hashes for otherwise identical proposals.
-    function salt(uint256) external view override {}
 
     /// @dev To send Ether with a call, the Timelock must call itself at this function. This avoids
     /// adding a rarely used `value` in the Call struct

--- a/contracts/utils/Timelock.sol
+++ b/contracts/utils/Timelock.sol
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: MIT
 // Inspired on Timelock.sol from Compound.
 // Special thanks to BoringCrypto and Mudit Gupta for their feedback.
+// Last audit on https://github.com/yieldprotocol/yield-utils-v2/commit/13190065ff409741d23836a33fd3d6c3059c3461
 
 pragma solidity ^0.8.0;
 import "../access/AccessControl.sol";

--- a/contracts/utils/Timelock.sol
+++ b/contracts/utils/Timelock.sol
@@ -16,11 +16,11 @@ interface ITimelock {
 
     function setDelay(uint32 delay_) external;
     function propose(Call[] calldata functionCalls) external returns (bytes32 txHash);
-    function proposeRepeated(Call[] calldata functionCalls, uint256 salt) external returns (bytes32 txHash);
     function approve(bytes32 txHash) external returns (uint32);
     function cancel(bytes32 txHash) external;
     function execute(Call[] calldata functionCalls) external returns (bytes[] calldata results);
-    function executeRepeated(Call[] calldata functionCalls, uint256 salt) external returns (bytes[] calldata results);
+    function salt(uint256) external view;
+    function callWithValue(Call calldata functionCall, uint256 value) external returns (bytes memory result);
 }
 
 contract Timelock is ITimelock, AccessControl {
@@ -54,16 +54,12 @@ contract Timelock is ITimelock, AccessControl {
         // governor should keep the `propose` and `execute` permissions, but use them only in emergency situations
         // (such as all trusted individuals going rogue).
         _grantRole(ITimelock.propose.selector, governor);
-        _grantRole(ITimelock.proposeRepeated.selector, governor);
         _grantRole(ITimelock.approve.selector, governor);
         _grantRole(ITimelock.cancel.selector, governor);
         _grantRole(ITimelock.execute.selector, governor);
-        _grantRole(ITimelock.executeRepeated.selector, governor);
 
         _grantRole(ITimelock.propose.selector, executor);
-        _grantRole(ITimelock.proposeRepeated.selector, executor);
         _grantRole(ITimelock.execute.selector, executor);
-        _grantRole(ITimelock.executeRepeated.selector, executor);
 
         // Changing the delay must now be executed through this Timelock contract
         _grantRole(ITimelock.setDelay.selector, address(this)); // bytes4(keccak256("setDelay(uint256)"))
@@ -86,44 +82,14 @@ contract Timelock is ITimelock, AccessControl {
     function hash(Call[] calldata functionCalls)
         external pure returns (bytes32 txHash)
     {
-        return _hash(functionCalls, 0);
-    }
-
-    /// @dev Compute the hash for a proposal, with other identical proposals existing
-    /// @param salt Unique identifier for the transaction when repeatedly proposed. Chosen by governor.
-    function hashRepeated(Call[] calldata functionCalls, uint256 salt)
-        external pure returns (bytes32 txHash)
-    {
-        return _hash(functionCalls, salt);
-    }
-
-    /// @dev Compute the hash for a proposal
-    function _hash(Call[] calldata functionCalls, uint256 salt)
-        private pure returns (bytes32 txHash)
-    {
-        txHash = keccak256(abi.encode(functionCalls, salt));
+        txHash = keccak256(abi.encode(functionCalls));
     }
 
     /// @dev Propose a transaction batch for execution
     function propose(Call[] calldata functionCalls)
         external override auth returns (bytes32 txHash)
     {
-        return _propose(functionCalls, 0);
-    }
-
-    /// @dev Propose a transaction batch for execution, with other identical proposals existing
-    /// @param salt Unique identifier for the transaction when repeatedly proposed. Chosen by governor.
-    function proposeRepeated(Call[] calldata functionCalls, uint256 salt)
-        external override auth returns (bytes32 txHash)
-    {
-        return _propose(functionCalls, salt);
-    }
-
-    /// @dev Propose a transaction batch for execution
-    function _propose(Call[] calldata functionCalls, uint256 salt)
-        private returns (bytes32 txHash)
-    {
-        txHash = keccak256(abi.encode(functionCalls, salt));
+        txHash = keccak256(abi.encode(functionCalls));
         require(proposals[txHash].state == STATE.UNKNOWN, "Already proposed.");
         proposals[txHash].state = STATE.PROPOSED;
         emit Proposed(txHash);
@@ -157,22 +123,7 @@ contract Timelock is ITimelock, AccessControl {
     function execute(Call[] calldata functionCalls)
         external override auth returns (bytes[] memory results)
     {
-        return _execute(functionCalls, 0);
-    }
-    
-    /// @dev Execute a proposal, among several identical ones
-    /// @param salt Unique identifier for the transaction when repeatedly proposed. Chosen by governor.
-    function executeRepeated(Call[] calldata functionCalls, uint256 salt)
-        external override auth returns (bytes[] memory results)
-    {
-        return _execute(functionCalls, salt);
-    }
-
-    /// @dev Execute a proposal
-    function _execute(Call[] calldata functionCalls, uint256 salt)
-        private returns (bytes[] memory results)
-    {
-        bytes32 txHash = keccak256(abi.encode(functionCalls, salt));
+        bytes32 txHash = keccak256(abi.encode(functionCalls));
         Proposal memory proposal = proposals[txHash];
 
         require(proposal.state == STATE.APPROVED, "Not approved.");
@@ -191,9 +142,12 @@ contract Timelock is ITimelock, AccessControl {
         emit Executed(txHash);
     }
 
+    /// @dev Add a call to this function to obtain different hashes for otherwise identical proposals.
+    function salt(uint256) external view override {}
+
     /// @dev To send Ether with a call, the Timelock must call itself at this function. This avoids
     /// adding a rarely used `value` in the Call struct
-    function callWithValue(Call calldata functionCall, uint256 value) external returns (bytes memory result) {
+    function callWithValue(Call calldata functionCall, uint256 value) external override returns (bytes memory result) {
         require(msg.sender == address(this), "Only call from itself");
         bool success;
         (success, result) = functionCall.target.call{ value: value }(functionCall.data);

--- a/contracts/utils/Timelock.sol
+++ b/contracts/utils/Timelock.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 // Inspired on Timelock.sol from Compound.
 // Special thanks to BoringCrypto and Mudit Gupta for their feedback.
-// Last audit on https://github.com/yieldprotocol/yield-utils-v2/commit/13190065ff409741d23836a33fd3d6c3059c3461
+// Last audit by Trail of Bits on https://github.com/yieldprotocol/yield-utils-v2/commit/13190065ff409741d23836a33fd3d6c3059c3461
 
 pragma solidity ^0.8.0;
 import "../access/AccessControl.sol";

--- a/contracts/utils/Timelock.sol
+++ b/contracts/utils/Timelock.sol
@@ -19,7 +19,6 @@ interface ITimelock {
     function approve(bytes32 txHash) external returns (uint32);
     function cancel(bytes32 txHash) external;
     function execute(Call[] calldata functionCalls) external returns (bytes[] calldata results);
-    function salt(uint256) external view;
     function callWithValue(Call calldata functionCall, uint256 value) external returns (bytes memory result);
 }
 

--- a/test/005_timelock.ts
+++ b/test/005_timelock.ts
@@ -161,21 +161,6 @@ describe("Timelock", async function () {
       );
     });
 
-    it("allows proposing repeated transactions", async () => {
-      const txHash2 = await timelock.callStatic.proposeRepeated(
-        functionCalls,
-        1
-      );
-
-      await expect(await timelock.proposeRepeated(functionCalls, 1)).to.emit(
-        timelock,
-        "Proposed"
-      );
-      //      .withArgs(txHash, targets, data, eta)
-      const proposal = await timelock.proposals(txHash2);
-      expect(proposal.state).to.equal(STATE.PROPOSED);
-    });
-
     it("only the governor can approve", async () => {
       await expect(
         timelock.connect(otherAcc).approve(txHash)
@@ -206,21 +191,12 @@ describe("Timelock", async function () {
       let timestamp: number;
       let now: BigNumber;
       let eta: BigNumber;
-      let txHash2: string;
-      let txHash3: string;
 
       beforeEach(async () => {
         ({ timestamp } = await ethers.provider.getBlock("latest"));
         now = BigNumber.from(timestamp);
         eta = now.add(await timelock.delay()).add(100);
         await timelock.approve(txHash);
-
-        txHash2 = await timelock.callStatic.proposeRepeated(functionCalls, 1);
-        await timelock.proposeRepeated(functionCalls, 1);
-        await timelock.approve(txHash2);
-
-        txHash3 = await timelock.callStatic.proposeRepeated(functionCalls, 2);
-        await timelock.proposeRepeated(functionCalls, 2);
       });
 
       it("only the governor can execute", async () => {
@@ -316,23 +292,6 @@ describe("Timelock", async function () {
             .to.emit(target2, "Approval");
           //          .withArgs(governor, governor, 1)
           expect((await timelock.proposals(txHash)).state).to.equal(
-            STATE.UNKNOWN
-          );
-          expect(await target1.balanceOf(governor)).to.equal(1);
-          expect(await target2.allowance(timelock.address, governor)).to.equal(
-            1
-          );
-        });
-
-        it("executes a repeated transaction", async () => {
-          await expect(await timelock.executeRepeated(functionCalls, 1))
-            .to.emit(timelock, "Executed")
-            //          .withArgs(txHash, targets, data, eta)
-            .to.emit(target1, "Transfer")
-            //          .withArgs(null, governor, 1)
-            .to.emit(target2, "Approval");
-          //          .withArgs(governor, governor, 1)
-          expect((await timelock.proposals(txHash2)).state).to.equal(
             STATE.UNKNOWN
           );
           expect(await target1.balanceOf(governor)).to.equal(1);


### PR DESCRIPTION
Instead of having the whole `*Repeated` nonsense, if you want different hashes for otherwise identical proposals, you can just append a different `timelock.salt(x)` call to each proposal.