### PR TITLE
fix: update token rewards on setRewards

### DIFF
--- a/contracts/token/ERC20Rewards.sol
+++ b/contracts/token/ERC20Rewards.sol
@@ -85,6 +85,9 @@ contract ERC20Rewards is AccessControl, ERC20Permit {
             "Ongoing rewards"
         );
 
+        // Update the rewards per token so that we don't lose any rewards
+        _updateRewardsPerToken();
+
         rewardsPeriod.start = start;
         rewardsPeriod.end = end;
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@yield-protocol/utils-v2",
-  "version": "2.6.5",
+  "version": "2.6.6",
   "description": "Yield v2 utility contracts",
   "author": "Yield Inc.",
   "files": [

--- a/test/ERC20Rewards.t.sol
+++ b/test/ERC20Rewards.t.sol
@@ -381,7 +381,6 @@ abstract contract AfterProgramEnd is WithProgram {
     function setUp() public override virtual {
         super.setUp();
 
-        super.setUp();
         (, uint256 end) = vault.rewardsPeriod();
 
         vm.warp(end + 1);
@@ -391,10 +390,16 @@ abstract contract AfterProgramEnd is WithProgram {
 contract AfterProgramEndTest is AfterProgramEnd {
 
     function testSetNewRewards(uint32 start, uint32 end, uint96 rate) public {
+        // Collect data from previous period to make sure per token rewards are updated
+        (uint32 previousStart, uint32 previousEnd) = vault.rewardsPeriod();
+        (,, uint96 previousRate) = vault.rewardsPerToken();
+        vm.expectEmit(true, false, false, false);
+        emit RewardsPerTokenUpdated((previousEnd - previousStart) * previousRate);
+
+        // Setup a new rewards period
         end = uint32(bound(end, block.timestamp + 1, type(uint32).max));
         start = uint32(bound(start, block.timestamp, end - 1));
-
-        vm.expectEmit(true, false, false, false);
+        vm.expectEmit(true, true, true, false);
         emit RewardsSet(start, end, rate);
 
         vm.prank(admin);


### PR DESCRIPTION
Fix for [this](https://hackmd.io/@devtooligan/YieldStrategyV2Review2022-12-07#3-RewardsPerToken-can-be-lost-if-a-new-rewards-program-is-set-Low)