### PR TITLE
Token swapper

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@yield-protocol/utils-v2",
-  "version": "2.6.15",
+  "version": "2.6.16",
   "description": "Yield v2 utility contracts",
   "author": "Yield Inc.",
   "files": [

--- a/src/interfaces/IAccessControl.sol
+++ b/src/interfaces/IAccessControl.sol
@@ -1,0 +1,27 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity ^0.8.0;
+
+
+interface IAccessControl {
+    struct RoleData {
+        mapping (address => bool) members;
+        bytes4 adminRole;
+    }
+
+    event RoleAdminChanged(bytes4 indexed role, bytes4 indexed newAdminRole);
+    event RoleGranted(bytes4 indexed role, address indexed account, address indexed sender);
+    event RoleRevoked(bytes4 indexed role, address indexed account, address indexed sender);
+
+    function ROOT() external view returns (bytes4);
+    function LOCK() external view returns (bytes4);
+    function hasRole(bytes4 role, address account) external view returns (bool);
+    function getRoleAdmin(bytes4 role) external view returns (bytes4);
+    function setRoleAdmin(bytes4 role, bytes4 adminRole) external;
+    function grantRole(bytes4 role, address account) external;
+    function grantRoles(bytes4[] memory roles, address account) external;
+    function lockRole(bytes4 role) external;
+    function revokeRole(bytes4 role, address account) external;
+    function revokeRoles(bytes4[] memory roles, address account) external;
+    function renounceRole(bytes4 role, address account) external;
+}

--- a/src/interfaces/ITokenSwap.sol
+++ b/src/interfaces/ITokenSwap.sol
@@ -1,0 +1,25 @@
+pragma solidity ^0.8.0;
+
+import { IAccessControl } from "./IAccessControl.sol";
+import { IERC20 } from "../token/IERC20.sol";
+
+interface ITokenSwap is IAccessControl {
+    struct TokenIn {
+        IERC20 reverse;
+        uint96 ratio;
+        uint256 balance;
+    }
+
+    struct TokenOut {
+        IERC20 reverse;
+        uint256 balance;     
+    }
+
+    function tokensIn(IERC20 tokenIn) external view returns (TokenIn memory);
+    function tokensOut(IERC20 tokenOut) external view returns (TokenOut memory);
+    function register(IERC20 tokenIn, IERC20 tokenOut) external;
+    function unregister(IERC20 tokenIn, address to) external;
+    function swap(IERC20 tokenIn, address to) external;
+    function extract(IERC20 tokenIn, address to) external;
+    function recover(IERC20 token, address to) external;
+}

--- a/src/token/TokenSwap.sol
+++ b/src/token/TokenSwap.sol
@@ -1,0 +1,123 @@
+// SPDX-License-Identifier: BUSL-1.1
+pragma solidity >=0.8.15;
+import "./TransferHelper.sol";
+import "../access/AccessControl.sol";
+import "../utils/Cast.sol";
+
+
+/// @dev TokenSwap is a contract that can be used swap tokens at a fixed rate, with
+/// the aim of completely replacing the supply of a token by the funds supplied to
+/// this contract. It is meant to be used as a token upgrade, when other mechanisms fail.
+contract TokenSwap is AccessControl() {
+    using Cast for uint256;
+    using TransferHelper for IERC20;
+
+    event Registered(IERC20 indexed tokenIn, IERC20 indexed tokenOut, uint256 tokenInBalance, uint256 tokenOutBalance, uint96 ratio);
+    event Unregistered(IERC20 indexed tokenIn, IERC20 indexed tokenOut, uint256 tokenInBalance, uint256 tokenOutBalance);
+    event Swapped(IERC20 indexed tokenIn, IERC20 indexed tokenOut, uint256 tokenInAmount, uint256 tokenOutAmount);
+    event Extracted(IERC20 indexed tokenIn, uint256 tokenInBalance);
+    event Recovered(IERC20 indexed token, uint256 recovered);
+
+    struct TokenIn {
+        IERC20 reverse;
+        uint96 ratio;
+        uint256 balance;
+    }
+
+    struct TokenOut {
+        IERC20 reverse;
+        uint256 balance;     
+    }
+
+    mapping (IERC20 => TokenIn) public tokensIn;
+    mapping (IERC20 => TokenOut) public tokensOut;
+
+    /// @dev Register a token to be replaced, and the token to replace it with.
+    /// The ratio is calculated as the funds of the replacement token divided by the supply of the token to be replaced.
+    /// The tokens used as a replacement must have been sent to the contract before this call.
+    /// @param tokenIn_ The token to be replaced
+    /// @param tokenOut_ The token to replace it with
+    function register(IERC20 tokenIn_, IERC20 tokenOut_) external auth {
+        require(address(tokenIn_) != address(tokenOut_), "Same token");
+        require(address(tokensIn[tokenIn_].reverse) == address(0), "TokenIn already registered");
+        require(address(tokensOut[tokenOut_].reverse) == address(0), "TokenOut already registered");
+
+        uint96 ratio = (tokenOut_.balanceOf(address(this)) * 1e18 / tokenIn_.totalSupply()).u96();
+        uint256 tokenInBalance = tokenIn_.balanceOf(address(this));
+        uint256 tokenOutBalance = tokenOut_.balanceOf(address(this));
+        tokensIn[tokenIn_] = TokenIn(
+            tokenOut_, 
+            ratio,
+            tokenInBalance
+        );
+        tokensOut[tokenOut_] = TokenOut(
+            tokenIn_,
+            tokenOutBalance
+        );
+
+        emit Registered(tokenIn_, tokenOut_, tokenInBalance, tokenOutBalance, ratio);
+    }
+
+    /// @dev Unregister a token to be replaced, and the token to replace it with. Send all related tokens to a given address.
+    /// @param tokenIn_ The token to be replaced
+    /// @param to The address to send all tokens to
+    function unregister(IERC20 tokenIn_, address to) external auth {
+        TokenIn memory tokenIn = tokensIn[tokenIn_];
+        require(address(tokenIn.reverse) != address(0), "TokenIn not registered");
+        IERC20 tokenOut_ = tokenIn.reverse;
+
+        delete tokensIn[tokenIn_];
+        delete tokensOut[tokenOut_];
+
+        // We send all related funds to the given address to make sure it's a clean sweep, not just the tracked balances.
+        uint256 tokenInBalance = tokenIn_.balanceOf(address(this));
+        uint256 tokenOutBalance = tokenOut_.balanceOf(address(this));
+        tokenIn_.safeTransfer(to, tokenInBalance);
+        tokenOut_.safeTransfer(to, tokenOutBalance);
+
+        emit Unregistered(tokenIn_, tokenOut_, tokenInBalance, tokenOutBalance);
+    }
+
+    /// @dev Extract tokens replaced by this contract.
+    /// @param tokenIn_ The token to be replaced
+    /// @param to The address to send the tokens to
+    function extract(IERC20 tokenIn_, address to) external auth {
+        TokenIn memory tokenIn = tokensIn[tokenIn_];
+        require(address(tokenIn.reverse) != address(0), "TokenIn not registered");
+
+        tokensIn[tokenIn_].balance = 0;
+        tokenIn_.safeTransfer(to, tokenIn.balance);
+
+        emit Extracted(tokenIn_, tokenIn.balance);
+    }
+
+    /// @dev Recover tokens deposited to the contract by mistake
+    /// Be careful, the address passed on as a token is not verified to be a valid ERC20 token.
+    /// @param token The token to be recovered
+    /// @param to The address to send the tokens to
+    function recover(IERC20 token, address to) external auth {
+        require(address(tokensIn[token].reverse) == address(0), "TokenIn registered");
+        require(address(tokensOut[token].reverse) == address(0), "TokenOut registered");
+        uint256 recovered = token.balanceOf(address(this));
+        token.safeTransfer(to, token.balanceOf(address(this)));
+
+        emit Recovered(token, recovered);
+    }
+
+    /// @dev Swap a token for its replacement, at the registered ratio. The tokens must have been sent to the contract before this call.
+    /// @param tokenIn_ The token to be replaced
+    function swap(IERC20 tokenIn_, address to) external {
+        TokenIn memory tokenIn = tokensIn[tokenIn_];
+        require(address(tokenIn.reverse) != address(0), "TokenIn not registered");
+        IERC20 tokenOut_ = tokenIn.reverse;
+
+        uint256 tokenInAmount = tokenIn_.balanceOf(address(this)) - tokenIn.balance;
+        uint256 tokenOutAmount = tokenInAmount * tokenIn.ratio / 1e18;
+        tokensIn[tokenIn_].balance += tokenInAmount;
+        tokensOut[tokenOut_].balance -= tokenOutAmount;
+        
+        tokenOut_.safeTransfer(to, tokenOutAmount);
+
+        emit Swapped(tokenIn_, tokenOut_, tokenInAmount, tokenOutAmount);
+    }
+}

--- a/src/utils/Cast.sol
+++ b/src/utils/Cast.sol
@@ -53,6 +53,11 @@ library Cast {
         y = uint104(x);
     }
 
+    function u96(uint256 x) internal pure returns (uint96 y) {
+        require(x <= type(uint96).max, "Cast overflow");
+        y = uint96(x);
+    }
+
     function u32(uint256 x) internal pure returns (uint32 y) {
         require(x <= type(uint32).max, "Cast overflow");
         y = uint32(x);

--- a/test/TokenSwap.t.sol
+++ b/test/TokenSwap.t.sol
@@ -1,0 +1,259 @@
+// SPDX-License-Identifier: BUSL-1.1
+pragma solidity >=0.8.13;
+
+import "forge-std/Test.sol";
+import "forge-std/console2.sol";
+
+import "../src/token/TokenSwap.sol";
+import "../src/interfaces/ITokenSwap.sol";
+import { ERC20Mock } from "../src/mocks/ERC20Mock.sol";
+import { TestExtensions } from "./utils/TestExtensions.sol";
+import { TestConstants } from "./utils/TestConstants.sol";
+
+
+using stdStorage for StdStorage;
+
+abstract contract DeployedState is Test, TestExtensions, TestConstants {
+
+    struct TokenIn {
+        IERC20 reverse;
+        uint96 ratio;
+        uint256 balance;
+    }
+
+    struct TokenOut {
+        IERC20 reverse;
+        uint256 balance;     
+    }
+
+    event Registered(IERC20 indexed tokenIn, IERC20 indexed tokenOut, uint256 tokenInBalance, uint256 tokenOutBalance, uint96 ratio);
+    event Unregistered(IERC20 indexed tokenIn, IERC20 indexed tokenOut, uint256 tokenInBalance, uint256 tokenOutBalance);
+    event Swapped(IERC20 indexed tokenIn, IERC20 indexed tokenOut, uint256 tokenInBalance, uint256 tokenOutBalance);
+    event Extracted(IERC20 indexed tokenIn, uint256 tokenInBalance);
+    event Recovered(IERC20 indexed token, uint256 recovered);
+
+    IERC20 public tokenIn;
+    IERC20 public tokenOut;
+    IERC20 public tokenOther;
+    TokenSwap public tokenSwap;
+
+    address user;
+    address other;
+    address admin;
+    address me;
+
+    function setUp() public virtual {
+
+        //... Users ...
+        user = address(1);
+        other = address(2);
+        admin = address(3);
+        me = 0xb4c79daB8f259C7Aee6E5b2Aa729821864227e84;
+
+        tokenIn = IERC20(address(new ERC20Mock("Token In", "TIN")));
+        tokenOut = IERC20(address(new ERC20Mock("Token Out", "TOU")));
+        tokenOther = IERC20(address(new ERC20Mock("Token Other", "TOT")));
+        tokenSwap = new TokenSwap();
+
+        tokenSwap.grantRole(TokenSwap.register.selector, admin);
+        tokenSwap.grantRole(TokenSwap.unregister.selector, admin);
+        tokenSwap.grantRole(TokenSwap.extract.selector, admin);
+        tokenSwap.grantRole(TokenSwap.recover.selector, admin);
+
+        vm.label(user, "user");
+        vm.label(other, "other");
+        vm.label(admin, "admin");
+        vm.label(me, "me");
+        vm.label(address(tokenIn), "TokenIn");
+        vm.label(address(tokenOut), "TokenOut");
+    }
+}
+
+contract DeployedTest is DeployedState {
+
+    function testRegisterRevertsOnSameToken() public {
+        vm.expectRevert(bytes("Same token"));
+        vm.prank(admin);
+        tokenSwap.register(tokenIn, tokenIn);
+    }
+
+    function testUnregisterRevertsIfNotRegistered() public {
+        vm.expectRevert(bytes("TokenIn not registered"));
+        vm.prank(admin);
+        tokenSwap.unregister(tokenIn, other);
+    }
+
+    function testExtractRevertsIfNotRegistered() public {
+        vm.expectRevert(bytes("TokenIn not registered"));
+        vm.prank(admin);
+        tokenSwap.extract(tokenIn, other);
+    }
+
+    function testRegister() public {
+        uint256 tokenInSupply = 100e18;
+        uint256 tokenOutSupply = 101e18;
+        ERC20Mock(address(tokenIn)).mint(user, tokenInSupply);
+        ERC20Mock(address(tokenOut)).mint(address(tokenSwap), tokenOutSupply);
+        uint96 ratio = uint96(tokenOutSupply * 1e18 / tokenInSupply);
+        // vm.expectEmit(true, true, true, true);
+        // emit Registered(tokenIn, tokenOut, tokenInSupply, tokenOutSupply, ratio);
+
+        vm.prank(admin);
+        tokenSwap.register(tokenIn, tokenOut);
+
+        ITokenSwap.TokenIn memory tokenIn_ = ITokenSwap(address(tokenSwap)).tokensIn(tokenIn);
+        ITokenSwap.TokenOut memory tokenOut_ = ITokenSwap(address(tokenSwap)).tokensOut(tokenOut);
+        assertEq(tokenIn_.ratio, ratio);
+        assertEq(tokenIn_.balance, 0);
+        assertEq(address(tokenIn_.reverse), address(tokenOut));
+        assertEq(tokenOut_.balance, tokenOutSupply);
+        assertEq(address(tokenOut_.reverse), address(tokenIn));
+    }
+}
+
+abstract contract RegisteredState is DeployedState {
+
+    function setUp() public virtual override {
+        super.setUp();
+        uint256 tokenInSupply = 100e18;
+        uint256 tokenOutSupply = 101e18;
+        ERC20Mock(address(tokenIn)).mint(user, tokenInSupply);
+        ERC20Mock(address(tokenOut)).mint(address(tokenSwap), tokenOutSupply);
+        vm.prank(admin);
+        tokenSwap.register(tokenIn, tokenOut);
+    }
+}
+
+contract RegisteredTest is RegisteredState {
+
+    /// @dev Test you can't register the same token twice as tokenIn
+    function testRegisterRevertsOnSameTokenIn() public {
+        vm.expectRevert(bytes("TokenIn already registered"));
+        vm.prank(admin);
+        tokenSwap.register(tokenIn, tokenOther);
+    }
+
+    /// @dev Test you can't register the same token twice as tokenOut
+    function testRegisterRevertsOnSameTokenOut() public {
+        vm.expectRevert(bytes("TokenOut already registered"));
+        vm.prank(admin);
+        tokenSwap.register(tokenOther, tokenOut);
+    }
+
+    function testRecoverRevertsIfTokenIn() public {
+        vm.expectRevert(bytes("TokenIn registered"));
+        vm.prank(admin);
+        tokenSwap.recover(tokenIn, other);
+    }
+
+    function testRecoverRevertsIfTokenOut() public {
+        vm.expectRevert(bytes("TokenOut registered"));
+        vm.prank(admin);
+        tokenSwap.recover(tokenOut, other);
+    }
+
+    function testSwapRevertsIfNotRegistered() public {
+        vm.expectRevert(bytes("TokenIn not registered"));
+        vm.prank(user);
+        tokenSwap.swap(tokenOther, other);
+    }
+
+    function testSwap() public {
+        ITokenSwap.TokenIn memory tokenIn_ = ITokenSwap(address(tokenSwap)).tokensIn(tokenIn);
+        ITokenSwap.TokenOut memory tokenOut_ = ITokenSwap(address(tokenSwap)).tokensOut(tokenOut);
+        
+        uint256 tokenInAmount = tokenIn.balanceOf(user) / 10;
+        assertGt(tokenInAmount, 0);
+
+        uint256 expectedTokenInBalance = tokenIn_.balance + tokenInAmount;
+        uint256 expectedTokenOut = tokenInAmount * tokenIn_.ratio / 1e18;
+        uint256 expectedTokenOutBalance = tokenOut_.balance - expectedTokenOut;
+
+        vm.startPrank(user);
+        tokenIn.transfer(address(tokenSwap), tokenInAmount);
+
+        vm.expectEmit(true, true, true, true);
+        emit Swapped(tokenIn, tokenOut, tokenInAmount, expectedTokenOut);
+
+        tokenSwap.swap(tokenIn, other);
+        vm.stopPrank();
+
+        tokenIn_ = ITokenSwap(address(tokenSwap)).tokensIn(tokenIn);
+        tokenOut_ = ITokenSwap(address(tokenSwap)).tokensOut(tokenOut);
+
+        assertEq(tokenIn_.balance, expectedTokenInBalance);
+        assertEq(tokenOut_.balance, expectedTokenOutBalance);
+        assertEq(tokenOut.balanceOf(other), expectedTokenOut);
+    }
+
+    function testRecover() public {
+        uint256 tokenAmount = 100e18;
+        cash(tokenOther, address(tokenSwap), tokenAmount);
+
+        vm.startPrank(admin);
+
+        vm.expectEmit(true, true, true, false);
+        emit Recovered(tokenOther, tokenAmount);
+
+        tokenSwap.recover(tokenOther, other);
+        vm.stopPrank();
+
+        assertEq(tokenOther.balanceOf(other), tokenAmount);
+    }
+}
+
+abstract contract SwappedState is RegisteredState {
+    function setUp() public virtual override {
+        super.setUp();
+        
+        uint256 tokenInAmount = tokenIn.balanceOf(user) / 10;
+        assertGt(tokenInAmount, 0);
+
+        vm.startPrank(user);
+        tokenIn.transfer(address(tokenSwap), tokenInAmount);
+
+        tokenSwap.swap(tokenIn, address(0));
+        vm.stopPrank();
+    }
+}
+
+contract SwappedTest is SwappedState {
+    function testUnregister() public {
+        uint256 tokenInBalance = tokenIn.balanceOf(address(tokenSwap));
+        uint256 tokenOutBalance = tokenOut.balanceOf(address(tokenSwap));
+
+        vm.expectEmit(true, true, true, true);
+        emit Unregistered(tokenIn, tokenOut, tokenInBalance, tokenOutBalance);
+
+        vm.startPrank(admin);
+        tokenSwap.unregister(tokenIn, other);
+
+        assertEq(tokenIn.balanceOf(other), tokenInBalance);
+        assertEq(tokenOut.balanceOf(other), tokenOutBalance);
+
+        ITokenSwap.TokenIn memory tokenIn_ = ITokenSwap(address(tokenSwap)).tokensIn(tokenIn);
+        ITokenSwap.TokenOut memory tokenOut_ = ITokenSwap(address(tokenSwap)).tokensOut(tokenOut);
+
+        assertEq(tokenIn_.ratio, 0);
+        assertEq(tokenIn_.balance, 0);
+        assertEq(tokenOut_.balance, 0);
+        assertEq(address(tokenIn_.reverse), address(0));
+        assertEq(address(tokenOut_.reverse), address(0));
+    }
+
+    function testExtract() public {
+        uint256 tokenInBalance = tokenIn.balanceOf(address(tokenSwap));
+
+        vm.expectEmit(true, true, true, false);
+        emit Extracted(tokenIn, tokenInBalance);
+
+        vm.startPrank(admin);
+        tokenSwap.extract(tokenIn, other);
+
+        assertEq(tokenIn.balanceOf(other), tokenInBalance);
+
+        ITokenSwap.TokenIn memory tokenIn_ = ITokenSwap(address(tokenSwap)).tokensIn(tokenIn);
+
+        assertEq(tokenIn_.balance, 0);
+    }
+}


### PR DESCRIPTION
This contract allows to completely replace one token by another.

The replacement is on the whole supply of token A for the whole amount of token B supplied to the contract. It is intended to work as a token upgrade when other mechanisms fail, and the operation is designed as a call that can be chained in a batch.